### PR TITLE
Show question mark image if token ID ends in 10

### DIFF
--- a/frontend/src/components/InfoLil.tsx
+++ b/frontend/src/components/InfoLil.tsx
@@ -31,12 +31,21 @@ const InfoLil = ({ data, isFetching, isFetched }: Props) => {
         <Tab.Group as="div" className="flex flex-col-reverse">
           <Tab.Panels className="aspect-w-1 aspect-h-1 w-full">
             <Tab.Panel>
-              {isFetched && data?.[3] && (
+              
+              // Preview next token if data has been fetched & is not the lil
+              nounder's reward token ending in 10
+              // https://github.com/lilnounsDAO/lilnouns-monorepo/blob/59ff19a364e631d8e5484823e2982858d99daf8d/packages/nouns-contracts/contracts/NounsToken.sol#L165-L176
+              {isFetched && data?.[3] && data?.[1].mod(10) != 0 && (
                 <img
                   src={`data:image/svg+xml;base64,${data?.[2] || ""}`}
                   alt={"nouns"}
                   className="h-full w-full object-cover shadow-xl object-center sm:rounded-lg relative"
                 />
+              )}
+              
+              // Display question mark image if next token is lil nounder's reward
+              {data?.[3] !== undefined && data?.[1].mod(10) == 0 && (
+                <PendingLil data={data} />
               )}
 
               {data?.[3] === undefined && <PendingLil data={data} />}


### PR DESCRIPTION
Checking to ensure the next token previewed does not end in 10 (indicates lil nounder's reward token). This prevents the user from expecting to mint the wrong token. If this condition is met, the next token is not previewed and instead a question mark image will be shown.