### PR TITLE
Prevent preview of next token if ending in 10

### DIFF
--- a/frontend/src/components/InfoLil.tsx
+++ b/frontend/src/components/InfoLil.tsx
@@ -31,23 +31,22 @@ const InfoLil = ({ data, isFetching, isFetched }: Props) => {
         <Tab.Group as="div" className="flex flex-col-reverse">
           <Tab.Panels className="aspect-w-1 aspect-h-1 w-full">
             <Tab.Panel>
+              {/*
+              Display next lil noun if data has been fetched & is not the lil nounder's reward
 
-              // Display next token preview if data has been fetched & not the lil
-              nounder's reward.
-              // https://github.com/lilnounsDAO/lilnouns-monorepo/blob/59ff19a364e631d8e5484823e2982858d99daf8d/packages/nouns-contracts/contracts/NounsToken.sol#L165-L176
-              {isFetched && data?.[3] && data?.[1].mod(10) != 0 && (
+              https://github.com/lilnounsDAO/lilnouns-monorepo/blob/59ff19a364e631d8e5484823e2982858d99daf8d/packages/nouns-contracts/contracts/NounsToken.sol#L165-L176
+              */}
+              {isFetched && data?.[3] && !data?.[1].mod(10).isZero() && (
                 <img
                   src={`data:image/svg+xml;base64,${data?.[2] || ""}`}
                   alt={"nouns"}
                   className="h-full w-full object-cover shadow-xl object-center sm:rounded-lg relative"
                 />
               )}
-              
-              // Display a question mark image if next token is lil nounder's reward
-              {data?.[3] !== undefined && data?.[1].mod(10) == 0 && (
-                <PendingLil data={data} />
-              )}
-              
+
+              {/* Display a question mark image if next token is lil nounder's reward */}
+              {data?.[1].mod(10).isZero() && <PendingLil data={data} />}
+
               {data?.[3] === undefined && <PendingLil data={data} />}
             </Tab.Panel>
           </Tab.Panels>

--- a/frontend/src/components/InfoLil.tsx
+++ b/frontend/src/components/InfoLil.tsx
@@ -31,14 +31,23 @@ const InfoLil = ({ data, isFetching, isFetched }: Props) => {
         <Tab.Group as="div" className="flex flex-col-reverse">
           <Tab.Panels className="aspect-w-1 aspect-h-1 w-full">
             <Tab.Panel>
-              {isFetched && data?.[3] && (
+
+              // Display next token preview if data has been fetched & not the lil
+              nounder's reward.
+              // https://github.com/lilnounsDAO/lilnouns-monorepo/blob/59ff19a364e631d8e5484823e2982858d99daf8d/packages/nouns-contracts/contracts/NounsToken.sol#L165-L176
+              {isFetched && data?.[3] && data?.[1].mod(10) != 0 && (
                 <img
                   src={`data:image/svg+xml;base64,${data?.[2] || ""}`}
                   alt={"nouns"}
                   className="h-full w-full object-cover shadow-xl object-center sm:rounded-lg relative"
                 />
               )}
-
+              
+              // Display a question mark image if next token is lil nounder's reward
+              {data?.[3] !== undefined && data?.[1].mod(10) == 0 && (
+                <PendingLil data={data} />
+              )}
+              
               {data?.[3] === undefined && <PendingLil data={data} />}
             </Tab.Panel>
           </Tab.Panels>

--- a/frontend/src/components/InfoLil.tsx
+++ b/frontend/src/components/InfoLil.tsx
@@ -44,10 +44,8 @@ const InfoLil = ({ data, isFetching, isFetched }: Props) => {
                 />
               )}
 
-              {/* Display a question mark image if next token is lil nounder's reward */}
-              {data?.[1].mod(10).isZero() && <PendingLil data={data} />}
-
-              {data?.[3] === undefined && <PendingLil data={data} />}
+              {/* Display a question mark image if auction state data is undefined or next token is lil nounder's reward */}
+              {(data?.[3] === undefined || data?.[1].mod(10).isZero()) && <PendingLil data={data} />}
             </Tab.Panel>
           </Tab.Panels>
         </Tab.Group>


### PR DESCRIPTION
When the token ID ends in 10, this one and the next will not go to the minter. Currently the preview image is misleading for these tokens because the user expects the next token that is previewed. This code removes the preview for tokens ending in 10 (the Lil Nounder's reward) and instead displays a question mark image.