### PR TITLE
New global function for lil nounders token logic

### DIFF
--- a/frontend/src/components/AuctionBtn.tsx
+++ b/frontend/src/components/AuctionBtn.tsx
@@ -37,7 +37,7 @@ const AuctionBtn = ({ data, isFetching }: Props) => {
           <span className="w-full text-3xl text-slate-500">
             Fetching Block...
           </span>
-        ) : isLilNoundersToken({data}) ? (
+        ) : isLilNoundersToken(data) ? (
           <span className="w-full text-3xl">I&apos;m feeling lucky</span>
         ) : (
           <span className="w-full text-3xl">Settle auction</span>

--- a/frontend/src/components/AuctionBtn.tsx
+++ b/frontend/src/components/AuctionBtn.tsx
@@ -2,7 +2,7 @@ import type { Result } from "ethers/lib/utils";
 import { useAccount, useContractWrite, usePrepareContractWrite } from "wagmi";
 
 import { LilNounsOracle } from "../deployments/LilNounsOracle";
-import LoadingSpinner from "./LoadingSpinner";
+import isLilNoundersToken from "../utils/IsLilNoundersToken";
 
 interface Props {
   data: Result | undefined;
@@ -37,7 +37,7 @@ const AuctionBtn = ({ data, isFetching }: Props) => {
           <span className="w-full text-3xl text-slate-500">
             Fetching Block...
           </span>
-        ) : data?.[1].mod(10).isZero() ? (
+        ) : isLilNoundersToken({data}) ? (
           <span className="w-full text-3xl">I&apos;m feeling lucky</span>
         ) : (
           <span className="w-full text-3xl">Settle auction</span>

--- a/frontend/src/components/InfoLil.tsx
+++ b/frontend/src/components/InfoLil.tsx
@@ -33,7 +33,7 @@ const InfoLil = ({ data, isFetching, isFetched }: Props) => {
           <Tab.Panels className="aspect-w-1 aspect-h-1 w-full">
             <Tab.Panel>
               {/* Display next lil noun if data has been fetched & is not the lil nounder's reward */}
-              {isFetched && data?.[3] && !isLilNoundersToken({data}) && (
+              {isFetched && data?.[3] && !isLilNoundersToken(data) && (
                 <img
                   src={`data:image/svg+xml;base64,${data?.[2] || ""}`}
                   alt={"nouns"}
@@ -42,7 +42,7 @@ const InfoLil = ({ data, isFetching, isFetched }: Props) => {
               )}
 
               {/* Display a question mark image if auction state data is undefined or next token is lil nounder's reward */}
-              {(data?.[3] === undefined || isLilNoundersToken({data})) && <PendingLil data={data} />}
+              {(data?.[3] === undefined || isLilNoundersToken(data)) && <PendingLil data={data} />}
             </Tab.Panel>
           </Tab.Panels>
         </Tab.Group>

--- a/frontend/src/components/InfoLil.tsx
+++ b/frontend/src/components/InfoLil.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useAccount, useBlockNumber } from "wagmi";
 
 import { AuctionState } from "../pages";
+import isLilNoundersToken from "../utils/IsLilNoundersToken";
 import AuctionBtn from "./AuctionBtn";
 import Header from "./Header";
 import PendingLil from "./PendingLil";
@@ -31,12 +32,8 @@ const InfoLil = ({ data, isFetching, isFetched }: Props) => {
         <Tab.Group as="div" className="flex flex-col-reverse">
           <Tab.Panels className="aspect-w-1 aspect-h-1 w-full">
             <Tab.Panel>
-              {/*
-              Display next lil noun if data has been fetched & is not the lil nounder's reward
-
-              https://github.com/lilnounsDAO/lilnouns-monorepo/blob/59ff19a364e631d8e5484823e2982858d99daf8d/packages/nouns-contracts/contracts/NounsToken.sol#L165-L176
-              */}
-              {isFetched && data?.[3] && !data?.[1].mod(10).isZero() && (
+              {/* Display next lil noun if data has been fetched & is not the lil nounder's reward */}
+              {isFetched && data?.[3] && !isLilNoundersToken({data}) && (
                 <img
                   src={`data:image/svg+xml;base64,${data?.[2] || ""}`}
                   alt={"nouns"}
@@ -45,7 +42,7 @@ const InfoLil = ({ data, isFetching, isFetched }: Props) => {
               )}
 
               {/* Display a question mark image if auction state data is undefined or next token is lil nounder's reward */}
-              {(data?.[3] === undefined || data?.[1].mod(10).isZero()) && <PendingLil data={data} />}
+              {(data?.[3] === undefined || isLilNoundersToken({data})) && <PendingLil data={data} />}
             </Tab.Panel>
           </Tab.Panels>
         </Tab.Group>

--- a/frontend/src/utils/IsLilNoundersToken.ts
+++ b/frontend/src/utils/IsLilNoundersToken.ts
@@ -15,4 +15,3 @@ const isLilNoundersToken = (data: Result | undefined) => {
 };
 
 export default isLilNoundersToken;
-

--- a/frontend/src/utils/IsLilNoundersToken.ts
+++ b/frontend/src/utils/IsLilNoundersToken.ts
@@ -1,17 +1,17 @@
 import type { Result } from "ethers/lib/utils";
 
-interface Props {
-  data: Result | undefined;
-}
-
 // If token is under the threshhold and ends in 10, return true
 // https://github.com/lilnounsDAO/lilnouns-monorepo/blob/59ff19a364e631d8e5484823e2982858d99daf8d/packages/nouns-contracts/contracts/NounsToken.sol#L165-L176
-const isLilNoundersToken = ({ data }: Props) => {
-  if (data?.[1].lte(175300) && data?.[1].mod(10).isZero()) {
-    return true;
-  } else {
+const isLilNoundersToken = (data: Result | undefined) => {
+  if (data?.[1].gte(175300)) {
     return false;
   }
+
+  if (!data?.[1].mod(10).isZero()) {
+    return false;
+  }
+
+  return true;
 };
 
 export default isLilNoundersToken;

--- a/frontend/src/utils/IsLilNoundersToken.ts
+++ b/frontend/src/utils/IsLilNoundersToken.ts
@@ -1,0 +1,17 @@
+import type { Result } from "ethers/lib/utils";
+
+interface Props {
+  data: Result | undefined;
+}
+
+// If token is under the threshhold and ends in 10, return true
+// https://github.com/lilnounsDAO/lilnouns-monorepo/blob/59ff19a364e631d8e5484823e2982858d99daf8d/packages/nouns-contracts/contracts/NounsToken.sol#L165-L176
+const isLilNoundersToken = ({ data }: Props) => {
+  if (data?.[1].lte(175300) && data?.[1].mod(10).isZero()) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+export default isLilNoundersToken;

--- a/frontend/src/utils/IsLilNoundersToken.ts
+++ b/frontend/src/utils/IsLilNoundersToken.ts
@@ -15,3 +15,4 @@ const isLilNoundersToken = (data: Result | undefined) => {
 };
 
 export default isLilNoundersToken;
+


### PR DESCRIPTION
Ran `yarn build` on this beforehand and no issues were found.

This code creates a function to store the logic for the lil nounders token. Also incorporates the threshold, so this functionality will drop off after 175,300 Lil Noun tokens have been minted. This function is implemented in `AuctionBtn.tsx` and `InfoLil.tsx`.

Also removed `import LoadingSpinner from "./LoadingSpinner";` from `AuctionBtn.tsx` because it's no longer in use.