### PR TITLE
Adding line to explain Lil Nounders reward

### DIFF
--- a/frontend/src/components/Wtf.tsx
+++ b/frontend/src/components/Wtf.tsx
@@ -33,7 +33,7 @@ const Wtf = () => {
               Settling the auction allows you to mint the shown Lil Noun as the next auction.{" "}
             </li>
             <li className="mb-2">
-              If the token number ends in 10, you won't be able to preview the next Lil Noun.{" "}
+              If the token number is divisible by 10, you won't be able to preview the next Lil Noun.{" "}
             </li>
             <li className="mb-2">
               Settlement and wallet confirmation have to happen all within the current block.

--- a/frontend/src/components/Wtf.tsx
+++ b/frontend/src/components/Wtf.tsx
@@ -33,6 +33,9 @@ const Wtf = () => {
               Settling the auction allows you to mint the shown Lil Noun as the next auction.{" "}
             </li>
             <li className="mb-2">
+              If the token number ends in 10, you won't be able to preview the next Lil Noun.{" "}
+            </li>
+            <li className="mb-2">
               Settlement and wallet confirmation have to happen all within the current block.
             </li>
             <li className="mb-2">


### PR DESCRIPTION
Adding a line in the summary section to explain why the user is unable to preview the next lil noun for tokens ending in 10.